### PR TITLE
解决view pager page scale变化后view点击坐标不准确问题

### DIFF
--- a/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
+++ b/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
@@ -25,9 +25,9 @@ public class ClipViewPager extends ViewPager {
         if (ev.getAction() == MotionEvent.ACTION_UP) {
             View view = viewOfClickOnScreen(ev);
             if (view != null) {
-                int index = indexOfChild(view);
+                int index = (Integer) view.getTag();
                 if (getCurrentItem() != index) {
-                    setCurrentItem(indexOfChild(view));
+                    setCurrentItem(index);
                 }
             }
         }
@@ -44,6 +44,7 @@ public class ClipViewPager extends ViewPager {
         int[] location = new int[2];
         for (int i = 0; i < childCount; i++) {
             View v = getChildAt(i);
+            int position = (Integer) v.getTag();
             v.getLocationOnScreen(location);
             int minX = location[0];
             int minY = getTop();
@@ -51,12 +52,12 @@ public class ClipViewPager extends ViewPager {
             int maxX = location[0] + v.getWidth();
             int maxY = getBottom();
 
-            if(i < currentIndex){
+            if(position < currentIndex){
                 maxX -= v.getWidth() * (1 - ScalePageTransformer.MIN_SCALE) * 0.5 + v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
                 minX -= v.getWidth() * (1 - ScalePageTransformer.MIN_SCALE) * 0.5 + v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
-            }else if(i == currentIndex){
+            }else if(position == currentIndex){
                 minX += v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE));
-            }else if(i > currentIndex){
+            }else if(position > currentIndex){
                 maxX -= v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
                 minX -= v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
             }

--- a/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
+++ b/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
@@ -40,6 +40,7 @@ public class ClipViewPager extends ViewPager {
      */
     private View viewOfClickOnScreen(MotionEvent ev) {
         int childCount = getChildCount();
+        int currentIndex = getCurrentItem();
         int[] location = new int[2];
         for (int i = 0; i < childCount; i++) {
             View v = getChildAt(i);
@@ -50,8 +51,17 @@ public class ClipViewPager extends ViewPager {
             int maxX = location[0] + v.getWidth();
             int maxY = getBottom();
 
-            float x = ev.getX();
-            float y = ev.getY();
+            if(i < currentIndex){
+                maxX -= v.getWidth() * (1 - ScalePageTransformer.MIN_SCALE) * 0.5 + v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
+                minX -= v.getWidth() * (1 - ScalePageTransformer.MIN_SCALE) * 0.5 + v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
+            }else if(i == currentIndex){
+                minX += v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE));
+            }else if(i > currentIndex){
+                maxX -= v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
+                minX -= v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;
+            }
+            float x = ev.getRawX();
+            float y = ev.getRawY();
 
             if ((x > minX && x < maxX) && (y > minY && y < maxY)) {
                 return v;

--- a/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
+++ b/app/src/main/java/com/hhl/tubatu/ClipViewPager.java
@@ -47,10 +47,10 @@ public class ClipViewPager extends ViewPager {
             int position = (Integer) v.getTag();
             v.getLocationOnScreen(location);
             int minX = location[0];
-            int minY = getTop();
+            int minY = location[1];
 
             int maxX = location[0] + v.getWidth();
-            int maxY = getBottom();
+            int maxY = location[1] + v.getHeight();
 
             if(position < currentIndex){
                 maxX -= v.getWidth() * (1 - ScalePageTransformer.MIN_SCALE) * 0.5 + v.getWidth() * (Math.abs(1 - ScalePageTransformer.MAX_SCALE)) * 0.5;

--- a/app/src/main/java/com/hhl/tubatu/MainActivity.java
+++ b/app/src/main/java/com/hhl/tubatu/MainActivity.java
@@ -66,8 +66,17 @@ public class MainActivity extends AppCompatActivity {
         list.add(R.drawable.style_dny);
         list.add(R.drawable.style_rishi);
 
+        list.add(R.drawable.style_xiandai);
+        list.add(R.drawable.style_jianyue);
+        list.add(R.drawable.style_oushi);
+        list.add(R.drawable.style_zhongshi);
+        list.add(R.drawable.style_meishi);
+        list.add(R.drawable.style_dzh);
+        list.add(R.drawable.style_dny);
+        list.add(R.drawable.style_rishi);
+
         //设置OffscreenPageLimit
-        mViewPager.setOffscreenPageLimit(list.size());
+        mViewPager.setOffscreenPageLimit(Math.min(list.size(), 5));
         mPagerAdapter.addAll(list);
     }
 


### PR DESCRIPTION
之前在调试过程中发现点击事件坐标不准确，commit中使用getRaw获取点击后在屏幕上的绝对坐标，然后对page scale之后的坐标进行了调整，使其匹配在点击中的实际坐标。
